### PR TITLE
Using AWS Secret Manager for Storage

### DIFF
--- a/AWS-Secrets.md
+++ b/AWS-Secrets.md
@@ -1,5 +1,5 @@
 # AWS Secret Manager
-## This is a rough approximation of how to leverage AWS Secrets Manager as a secret store for the Agent Registration Code.  There is an assumption that you are familiar with AWS, IAM, and EKS and how the 3 interact.
+## Tehse are some sample steps of how to leverage AWS Secrets Manager as a secret store for the Agent Registration Code.  There is an assumption that you are familiar with AWS, IAM, and EKS and how the 3 interact.
 
 - Store the registration keys in secrets manager and get the ARN for it
     ```

--- a/AWS-Secrets.md
+++ b/AWS-Secrets.md
@@ -1,0 +1,44 @@
+# AWS Secret Manager
+## This is a rough approximation of how to leverage AWS Secrets Manager as a secret store for the Agent Registration Code.  There is an assumption that you are familiar with AWS, IAM, and EKS and how the 3 interact.
+
+- Store the registration keys in secrets manager and get the ARN for it
+    ```
+    aws secretsmanager create-secret --name \<name\> --region \<region\>
+    - aws secretsmanager put-secret-value --secret-id \<name\> --region \<region\> --secret-string "{\"spyderbat-registration-key\":\"\<key\>\"}"
+    aws secretsmanager get-secret-value --secret-id \<name\> --region \<region\>
+
+- Create an IAM Policy that allows GetSecretValue and DescribeSecret for it.
+
+- Add the AWS secrets store csi driver to your cluster if it is not already available.
+    ```
+    helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+
+    helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver --namespace kube-system --set syncSecret.enabled=true
+
+    kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml
+    ```
+
+- Create a role that will have access to the above mentioned policy and is federated to your eks cluster (see associate-iam-oidc-provider)
+    ```
+    eksctl create iamserviceaccount --name spyderbat-serviceaccount --region="<region>" --cluster "<cluster_name>" --attach-policy-arn "<policy_arn>" --approve --namespace spyderbat
+
+    eksctl get iamserviceaccount --name spyderbat-serviceaccount --region="<region>" --cluster "<cluster_name>" --namespace spyderbat
+    ```
+
+- Now that you have all those values, you can helm install the nanoagent to reference that secret and mount it accordingly (you can do this either via your own values.yaml or overriding via --set via the Helm CLI).
+    ```
+    aws:
+        secretsmanager:
+            enabled: true
+            rolearn: "<role_arn>"
+            secretarn: "<secret_arn>"
+    ```
+    
+    ```
+    helm repo add nanoagent https://spyderbat.github.io/nanoagent_helm/
+    helm repo update
+    helm install nanoagent nanoagent/nanoagent \  --set nanoagent.orcurl="<orc_url>" \  --namespace spyderbat \  --create-namespace \  --set CLUSTER_NAME="<cluster_name>"
+    ```
+
+##
+This is one example of how this can be accomplished.  If you have any questions feel free to reach out to us at support@spyderbat.com.

--- a/AWS-Secrets.md
+++ b/AWS-Secrets.md
@@ -1,5 +1,5 @@
 # AWS Secret Manager
-## Tehse are some sample steps of how to leverage AWS Secrets Manager as a secret store for the Agent Registration Code.  There is an assumption that you are familiar with AWS, IAM, and EKS and how the 3 interact.
+## These are some sample steps of how to leverage AWS Secrets Manager as a secret store for the Agent Registration Code.  There is an assumption that you are familiar with AWS, IAM, and EKS and how the 3 interact.
 
 - Store the registration keys in secrets manager and get the ARN for it
     ```

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Default settings that can be altered in Values.yaml
 |Priority class	| priorityClassDefault	        | enabled: false | 	1000                      |                                                                                                                                                                                                                  |
 |Namespace	| namespaceSpyderbat	          | enabled: true	 | spyderbat                  |                                                                                                                                                                                                                  |
 |Omit Envionment | OMITENVIRONMENT | | "no" | "no" emit all environment variables. "everything" omits all environment variables and "allbutredacted" uses our rules to encrypt variables that look like they contain secrets and emit only those for analysis. |
-
-
+|AWS Secrets Manager | aws:secretsmanager:enabled | | false | Whether to use AWS SM integration to retrieve agent registration code. |
+|AWS Secrets Manager | aws:secretsmanager:rolearn| | ""| The arn of the role for the eks spyderbat service account to assume|
+|AWS Secrets Manager | aws:secretsmanager:secretarn| | "" | the arn of the secret that the pods will attempt to mount to read the registration code from.|
 
 
 To configure access via a proxy you can add additional parameters to the Helm command line:

--- a/templates/clustermonitor.yaml
+++ b/templates/clustermonitor.yaml
@@ -27,7 +27,7 @@ spec:
           image: {{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullpolicy }}
 {{- if .Values.aws.secretsmanager.enabled }}
-          command: ["/bin/sh","-c"]
+          command: ["/bin/bash","-c"]
           args: ["AGENT_REGISTRATION_CODE=`cat /mnt/spyderbat-credentials/spyderbat-registration-key` ./boot_strap.sh"]
           volumeMounts:
             - name: secrets-store-inline

--- a/templates/clustermonitor.yaml
+++ b/templates/clustermonitor.yaml
@@ -26,13 +26,19 @@ spec:
         - name: clustermonitor
           image: {{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullpolicy }}
+{{- if .Values.aws.secretsmanager.enabled }}
           command: ["/bin/sh","-c"]
           args: ["AGENT_REGISTRATION_CODE=`cat /mnt/spyderbat-credentials/spyderbat-registration-key` ./boot_strap.sh"]
           volumeMounts:
             - name: secrets-store-inline
               mountPath: "/mnt/spyderbat-credentials"
               readOnly: true
+{{- end }}
           env:
+{{- if eq .Values.aws.secretsmanager.enabled false }}
+            - name: AGENT_REGISTRATION_CODE
+              value: {{ .Values.nanoagent.agentRegistrationCode  }}
+{{- end }}
             - name: ORC_URL
               value: {{  .Values.nanoagent.orcurl }}
             - name: http_proxy
@@ -63,6 +69,7 @@ spec:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
+{{- if .Values.aws.secretsmanager.enabled }}
       volumes:
       - name: secrets-store-inline
         csi:
@@ -70,3 +77,4 @@ spec:
           readOnly: true
           volumeAttributes:
             secretProviderClass: "spyderbat-credentials"
+{{- end }}

--- a/templates/clustermonitor.yaml
+++ b/templates/clustermonitor.yaml
@@ -26,9 +26,13 @@ spec:
         - name: clustermonitor
           image: {{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullpolicy }}
+          command: ["/bin/sh","-c"]
+          args: ["AGENT_REGISTRATION_CODE=`cat /mnt/spyderbat-credentials/spyderbat-registration-key` ./boot_strap.sh"]
+          volumeMounts:
+            - name: secrets-store-inline
+              mountPath: "/mnt/spyderbat-credentials"
+              readOnly: true
           env:
-            - name: AGENT_REGISTRATION_CODE
-              value: {{ .Values.nanoagent.agentRegistrationCode  }}
             - name: ORC_URL
               value: {{  .Values.nanoagent.orcurl }}
             - name: http_proxy
@@ -51,7 +55,7 @@ spec:
 {{- if .Values.OMITENVIRONMENT }}
             - name: OMITENVIRONMENT
               value: "{{ .Values.OMITENVIRONMENT }}"
-{{- end }}              
+{{- end }}
           resources:
             requests:
               cpu: {{ .Values.resources.requests.cpu }}
@@ -59,3 +63,10 @@ spec:
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
+      volumes:
+      - name: secrets-store-inline
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: "spyderbat-credentials"

--- a/templates/nanoagent.yaml
+++ b/templates/nanoagent.yaml
@@ -26,6 +26,7 @@ spec:
 {{ toYaml .Values.nanoagent.pod.annotations | indent 8 }}
 {{- end }}
     spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       hostPID: true
       hostNetwork: true
 {{- if .Values.nanoagent.nodeSelector }}
@@ -47,9 +48,9 @@ spec:
         - name: spyderbat-nanoagent
           image: {{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullpolicy }}
+          command: ["/bin/sh","-c"]
+          args: ["AGENT_REGISTRATION_CODE=`cat /mnt/spyderbat-credentials/spyderbat-registration-key` ./boot_strap.sh"]
           env:
-            - name: AGENT_REGISTRATION_CODE
-              value: {{ .Values.nanoagent.agentRegistrationCode  }}
             - name: ORC_URL
               value: {{  .Values.nanoagent.orcurl }}
             - name: http_proxy
@@ -97,6 +98,9 @@ spec:
               readOnly: true
             - name: hostrun
               mountPath: /hostrun
+            - name: secrets-store-inline
+              mountPath: "/mnt/spyderbat-credentials"
+              readOnly: true
 {{- if .Values.microK8sSnap.enabled }}
             - name: hostsnap
               mountPath: /hostsnap
@@ -121,6 +125,12 @@ spec:
         - name: hostrun
           hostPath:
             path: /var/run
+        - name: secrets-store-inline
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "spyderbat-credentials"
 {{- if .Values.microK8sSnap.enabled }}
         - name: hostsnap
           hostPath:

--- a/templates/nanoagent.yaml
+++ b/templates/nanoagent.yaml
@@ -49,7 +49,7 @@ spec:
           image: {{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullpolicy }}
 {{- if .Values.aws.secretsmanager.enabled }}
-          command: ["/bin/sh","-c"]
+          command: ["/bin/bash","-c"]
           args: ["AGENT_REGISTRATION_CODE=`cat /mnt/spyderbat-credentials/spyderbat-registration-key` ./boot_strap.sh"]
 {{- end }}
           env:

--- a/templates/nanoagent.yaml
+++ b/templates/nanoagent.yaml
@@ -48,8 +48,10 @@ spec:
         - name: spyderbat-nanoagent
           image: {{ .Values.image.registry}}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullpolicy }}
+{{- if .Values.aws.secretsmanager.enabled }}
           command: ["/bin/sh","-c"]
           args: ["AGENT_REGISTRATION_CODE=`cat /mnt/spyderbat-credentials/spyderbat-registration-key` ./boot_strap.sh"]
+{{- end }}
           env:
             - name: ORC_URL
               value: {{  .Values.nanoagent.orcurl }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: spyderbat-credentials
+  namespace: spyderbat
+  labels:
+    {{- include "nanoagent.labels" . | nindent 4 }}
+spec:
+  provider: aws
+  parameters:
+    objects: |
+      - objectName: "arn:aws:secretsmanager:us-east-2:429857113775:secret:beau/dev/eks-csi-roobat-M1mBZk"
+        jmesPath: 
+          - path: "\"spyderbat-registration-key\""
+            objectAlias: spyderbat-registration-key
+

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.aws.secretsmanager.enabled -}}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
@@ -9,8 +10,8 @@ spec:
   provider: aws
   parameters:
     objects: |
-      - objectName: "arn:aws:secretsmanager:us-east-2:429857113775:secret:beau/dev/eks-csi-roobat-M1mBZk"
-        jmesPath: 
+      - objectName: {{ .Values.aws.secretsmanager.secretarn }}
+        jmesPath:
           - path: "\"spyderbat-registration-key\""
             objectAlias: spyderbat-registration-key
-
+{{- end }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     {{- include "nanoagent.labels" . | nindent 4 }}
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::429857113775:role/eksctl-amazing-rainbow-1689885478-addon-iams-Role1-O1Z4QM13CADJ
+{{- if eq .Values.aws.secretsmanager.enabled true }}
+    eks.amazonaws.com/role-arn: {{ .Values.aws.secretsmanager.rolearn }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
-
-
 {{- end }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
     {{- include "nanoagent.labels" . | nindent 4 }}
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::429857113775:role/eksctl-amazing-rainbow-1689885478-addon-iams-Role1-O1Z4QM13CADJ
   namespace: {{ .Release.Namespace }}
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,3 @@
-
 # Image location for Spyderbat Nano Agent
 image:
   registry: public.ecr.aws
@@ -15,7 +14,6 @@ kubernetesSupport:
   enabled: true
   apiAuth: /var/run/secrets/kubernetes.io/serviceaccount/token
   apiUrl: "https://$(KUBERNETES_SERVICE_HOST)"
-
 
 # Reasonable resource defaults.  May need to be larger on particularly large systems.  We recommend about 3-5% of the system resources for a node.
 # Before deploying to production please make sure these limits are sane to protect your work load.
@@ -40,11 +38,11 @@ priorityClassDefault:
 serviceAccount:
   create: true
   name: spyderbat-serviceaccount
-  annotations: { }
+  annotations: {}
   role: cluster-admin
   readonly: false
-    
-microK8sSnap: 
+
+microK8sSnap:
   enabled: false
 
 # Cluster Name
@@ -58,6 +56,12 @@ OMITENVIRONMENT: "no"
 
 # Additional pod labels
 podLabels: {}
+
+aws:
+  secretsmanager:
+    enabled: false
+    rolearn: "arn:aws:iam::429857113775:role/eksctl-amazing-rainbow-1689885478-addon-iams-Role1-O1Z4QM13CADJ"
+    secretarn: "arn:aws:secretsmanager:us-east-2:429857113775:secret:beau/dev/eks-csi-roobat-M1mBZk"
 
 nanoagent:
   pod:


### PR DESCRIPTION
I stored the registration code in arn:aws:secretsmanager:us-east-2:429857113775:secret:beau/dev/eks-csi-roobat-M1mBZk and this allows us access to it.

```csi integration

eksctl create cluster —region us-east-2

eksctl utils associate-iam-oidc-provider --region="us-east-2" --cluster="amazing-rainbow-1689885478" --approve

POLICY_ARN=$(aws --region "us-east-2" --query Policy.Arn --output text iam create-policy --policy-name nanoagent-deployment-policy --policy-document '{
    "Version": "2012-10-17",
    "Statement": [ {
        "Effect": "Allow",
        "Action": ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
        "Resource": ["arn:aws:secretsmanager:us-east-2:429857113775:secret:beau/dev/eks-csi-roobat-M1mBZk"]
    } ]
}')

helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts

helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver --namespace kube-system --set syncSecret.enabled=true

kubectl apply -f https://raw.githubusercontent.com/aws/secrets-store-csi-driver-provider-aws/main/deployment/aws-provider-installer.yaml

eksctl create iamserviceaccount --name spyderbat-serviceaccount --region="us-east-2" --cluster "amazing-rainbow-1689885478" --attach-policy-arn "$POLICY_ARN" --approve --namespace spyderbat

eksctl get iamserviceaccount --name spyderbat-serviceaccount --region="us-east-2" --cluster "amazing-rainbow-1689885478" --namespace spyderbat # to get arn for role

helm install nanoagent . \  --set nanoagent.orcurl=https://orc.kangaroobat.net \  --namespace spyderbat \  --create-namespace \  --set CLUSTER_NAME=csisecrets \

```