### PR TITLE
Fixing the helm chart default memory limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Default settings that can be altered in Values.yaml
 |CPU resource request| 	requests: cpu               | 	N/A	          | 100m                       |                                                                                                                                                                                                                  |
 |CPU resource limit| 	limits: cpu     | 	N/A	          | 6000m                      |
 |Memory resource request| 	requests: memory            | 	N/A           | 	512Mi                     |                                                                                                                                                                                                                  |
-|Memory resource limit| 	limits: memory	| N/A	                               | 10240Mi         |                                                                                                                                                                                                                  |
+|Memory resource limit| 	limits: memory	| N/A	                               | 2048Mi         |                                                                                                                                                                                                                  |
 |Priority class	| priorityClassDefault	        | enabled: false | 	1000                      |                                                                                                                                                                                                                  |
 |Namespace	| namespaceSpyderbat	          | enabled: true	 | spyderbat                  |                                                                                                                                                                                                                  |
 |Omit Envionment | OMITENVIRONMENT | | "no" | "no" emit all environment variables. "everything" omits all environment variables and "allbutredacted" uses our rules to encrypt variables that look like they contain secrets and emit only those for analysis. |
@@ -35,7 +35,6 @@ To set the resource limits additional parameters like there can be added to the 
 ```
 
 A readonly service account can be used instead of the read/write one.   This can be enabled by setting serviceAccount.readonly to true and then using spyderbat-cluster-readonly in serviceAccount.role.   Doing this will prevent kubernetes "actions" from being functional, killing a pod with guardian will not function properly.
-
 
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -24,7 +24,7 @@ resources:
     memory: 512Mi
   limits:
     cpu: 6000m
-    memory: 10240Mi
+    memory: 2048Mi
 
 # Priority class for Spyderbat Nano Agent.   An agent is desired on each node of the cluster
 # Disabled by default to prevent doing harm.


### PR DESCRIPTION
Setting the memory limit to something more reasonable.  This is still a fairly conservative value.