### PR TITLE
Add conditionals for writerole/clustermonitor

### DIFF
--- a/templates/clustermonitor.yaml
+++ b/templates/clustermonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clusterMonitor.create -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -82,4 +83,5 @@ spec:
           readOnly: true
           volumeAttributes:
             secretProviderClass: "spyderbat-credentials"
+{{- end }}
 {{- end }}

--- a/templates/rolebinding.yaml
+++ b/templates/rolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: spyderbat-rolebinding-cluster
+  name: spyderbat-rolebinding-cluster-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/writerole.yaml
+++ b/templates/writerole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.writeRole.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -10,4 +11,4 @@ rules:
 - apiGroups: ["*"]
   resources: ["pods"]
   verbs: ["delete", "watch", "get", "list"]
-
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -75,3 +75,16 @@ nanoagent:
 
   ## The affinity of the pods
   affinity: {}
+
+# Whether or not the clusterMonitor deployment should be created.
+# If set to false the deployment will not be created, this is useful for
+# multiple deployments of the chart on the same cluster, the clusterMonitor
+# deployment must be one per cluster.
+clusterMonitor:
+  create: true
+
+# Whether or not the write ClusterRole should be created.
+# If set to false the role will not be created. Useful for multiple deployments
+# of the chart on the same cluster. The role is needed only once per cluster
+writeRole:
+  create: true


### PR DESCRIPTION
Add `clusterMonitor.create` and `writeRole.create` values that control the conditional creation of the `clusterMonitor` deployment and the `spyderbat-cluster-write` clusterrole respectively. The default of the new values is `true` to not change the previous behaviour.

The behaviour has changed for the clusterrolebinding, where the name now includes the release namespace.

These changes are useful for running multiple copies of the chart in the same cluster, where the first instance creates both the `clusterMonitor` deployment and the `spyderbat-cluster-write` and all other copies do not.

This is necessary when the cluster runs on heterogeneous node with vastly different sizes (e.g. nodes with 8 CPUs along side ones with 192 CPUs), where the memory and cpu limits configuration need to be tuned correctly.